### PR TITLE
feat: new optional way of not blocking the view while xandr is initialising

### DIFF
--- a/packages/xandr/example/lib/main.dart
+++ b/packages/xandr/example/lib/main.dart
@@ -5,7 +5,6 @@ import 'package:xandr/ad_banner.dart';
 import 'package:xandr/ad_size.dart';
 import 'package:xandr/load_mode.dart';
 import 'package:xandr/xandr.dart';
-import 'package:xandr/xandr_builder.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -52,7 +51,7 @@ class _XandrExampleState extends State<XandrExample> {
   void initState() {
     super.initState();
 
-    _controller = XandrController();
+    _controller = XandrController()..init(9517);
     _scrollController.addListener(() {
       _checkIfAdIsInViewport.add(_scrollController.position);
     });
@@ -66,181 +65,157 @@ class _XandrExampleState extends State<XandrExample> {
         title: const Text('xandr sample - banner'),
       ),
       body: Center(
-        child: XandrBuilder(
-          controller: _controller,
-          memberId: 9517, //10094,
-          builder: (context, snapshot) {
-            if (snapshot.hasData) {
-              debugPrint('Xandr SDK initialized, success=${snapshot.hasData}');
-              return SingleChildScrollView(
-                controller: _scrollController,
-                child: Column(
-                  children: [
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to m'),
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 8),
-                      child: Align(
-                        alignment: Alignment.topLeft,
-                        child: Text(
-                          'fit to container:',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          child: Column(
+            children: [
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to m'),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    'fit to container:',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
                     ),
-                    AdBanner(
-                      controller: _controller,
-                      //placementID: '17058950',
-                      inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
-                      adSizes: const [AdSize(728, 90)], //[AdSize(300, 250)],
-                      //customKeywords: useDemoAds,
-                      resizeAdToFitContainer: true,
-                      enableLazyLoad: true,
-                    ),
-                    //FIXME: not working
-                    //const Text(
-                    //  'Lorem Ipsum is simply dummy text of the printing and '
-                    //  'typesetting industry. Lorem Ipsum has been the boo '
-                    //  'standard dummy text ever since the 1500s, when an aha '
-                    //  'printer took a galley of type and scrambled it to n'),
-                    //const Padding(
-                    //  padding: EdgeInsets.symmetric(vertical: 8),
-                    //  child: Align(
-                    //    alignment: Alignment.topLeft,
-                    //    child: Text(
-                    //      'crop to reserved space:',
-                    //      style: TextStyle(
-                    //        fontWeight: FontWeight.bold,
-                    //      ),
-                    //    ),
-                    //  ),
-                    //),
-                    //AdBanner(
-                    //  controller: _controller,
-                    //  //placementID: '17058950',
-                    //  inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
-                    //  adSizes: const [
-                    //    AdSize(1, 1),
-                    //    AdSize(728, 90),
-                    //  ], //[AdSize(300, 250)],
-                    //  width: 90,
-                    //  height: 90,
-                    //  //customKeywords: useDemoAds,
-                    //  resizeWhenLoaded: true,
-                    //),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to v'),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to v'),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to v'),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to v'),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to v'),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to v'),
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 8),
-                      child: Align(
-                        alignment: Alignment.topLeft,
-                        child: Text(
-                          'use winning ad size:',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
-                    AdBanner(
-                      controller: _controller,
-                      //placementID: '17058950',
-                      inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
-                      adSizes: const [
-                        AdSize(1, 1),
-                        AdSize(728, 90),
-                      ], //[AdSize(300, 250)],
-                      width: 90,
-                      height: 90,
-                      loadsInBackground: true,
-                    ),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to g'),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to g'),
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 8),
-                      child: Align(
-                        alignment: Alignment.topLeft,
-                        child: Text(
-                          'load when in viewport:',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
-                    AdBanner(
-                      controller: _controller,
-                      //placementID: '17058950',
-                      inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
-                      adSizes: const [
-                        AdSize(728, 90),
-                        AdSize(1, 1),
-                      ],
-                      resizeAdToFitContainer: true,
-                      loadMode: LoadMode.whenInViewport(
-                        _checkIfAdIsInViewport.stream,
-                      ),
-                    ),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to g'),
-                    const Text(
-                        'Lorem Ipsum is simply dummy text of the printing and '
-                        'typesetting industry. Lorem Ipsum has been the boo '
-                        'standard dummy text ever since the 1500s, when an aha '
-                        'printer took a galley of type and scrambled it to g'),
-                  ],
+                  ),
                 ),
-              );
-            } else if (snapshot.hasError) {
-              return const Text('Error initializing Xandr SDK');
-            } else {
-              return const Text('Initializing Xandr SDK...');
-            }
-          },
+              ),
+              AdBanner(
+                controller: _controller,
+                //placementID: '17058950',
+                inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+                adSizes: const [AdSize(728, 90)], //[AdSize(300, 250)],
+                //customKeywords: useDemoAds,
+                resizeAdToFitContainer: true,
+                enableLazyLoad: true,
+              ),
+              //FIXME: not working
+              //const Text(
+              //  'Lorem Ipsum is simply dummy text of the printing and '
+              //  'typesetting industry. Lorem Ipsum has been the boo '
+              //  'standard dummy text ever since the 1500s, when an aha '
+              //  'printer took a galley of type and scrambled it to n'),
+              //const Padding(
+              //  padding: EdgeInsets.symmetric(vertical: 8),
+              //  child: Align(
+              //    alignment: Alignment.topLeft,
+              //    child: Text(
+              //      'crop to reserved space:',
+              //      style: TextStyle(
+              //        fontWeight: FontWeight.bold,
+              //      ),
+              //    ),
+              //  ),
+              //),
+              //AdBanner(
+              //  controller: _controller,
+              //  //placementID: '17058950',
+              //  inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+              //  adSizes: const [
+              //    AdSize(1, 1),
+              //    AdSize(728, 90),
+              //  ], //[AdSize(300, 250)],
+              //  width: 90,
+              //  height: 90,
+              //  //customKeywords: useDemoAds,
+              //  resizeWhenLoaded: true,
+              //),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to v'),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to v'),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to v'),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to v'),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to v'),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to v'),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    'use winning ad size:',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              AdBanner(
+                controller: _controller,
+                //placementID: '17058950',
+                inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+                adSizes: const [
+                  AdSize(1, 1),
+                  AdSize(728, 90),
+                ], //[AdSize(300, 250)],
+                width: 90,
+                height: 90,
+                loadsInBackground: true,
+              ),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to g'),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to g'),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    'load when in viewport:',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              AdBanner(
+                controller: _controller,
+                //placementID: '17058950',
+                inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+                adSizes: const [
+                  AdSize(728, 90),
+                  AdSize(1, 1),
+                ],
+                resizeAdToFitContainer: true,
+                loadMode: LoadMode.whenInViewport(
+                  _checkIfAdIsInViewport.stream,
+                ),
+              ),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to g'),
+              const Text('Lorem Ipsum is simply dummy text of the printing and '
+                  'typesetting industry. Lorem Ipsum has been the boo '
+                  'standard dummy text ever since the 1500s, when an aha '
+                  'printer took a galley of type and scrambled it to g'),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/xandr/example/lib/main_multi_ad_request.dart
+++ b/packages/xandr/example/lib/main_multi_ad_request.dart
@@ -3,9 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:xandr/ad_banner.dart';
 import 'package:xandr/ad_size.dart';
-import 'package:xandr/multiadrequest_builder.dart';
 import 'package:xandr/xandr.dart';
-import 'package:xandr/xandr_builder.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -54,8 +52,10 @@ class _XandrExampleState extends State<XandrExample> {
   void initState() {
     super.initState();
 
-    _controller = XandrController();
-    _multiAdRequestController = MultiAdRequestController();
+    _controller = XandrController()..init(9517);
+    _multiAdRequestController =
+        MultiAdRequestController(controller: _controller)
+          ..initWhenXandrIsReady();
     _scrollController.addListener(() {
       _checkIfAdIsInViewport.add(_scrollController.position);
     });
@@ -69,141 +69,99 @@ class _XandrExampleState extends State<XandrExample> {
         title: const Text('xandr sample - multi ad request'),
       ),
       body: Center(
-        child: XandrBuilder(
-          controller: _controller,
-          memberId: 9517, //10094,
-          builder: (_, xandrSnapshot) {
-            if (xandrSnapshot.hasData) {
-              debugPrint(
-                'Xandr SDK initialized, success=${xandrSnapshot.data}',
-              );
-              return MultiAdRequestBuilder(
-                controller: _multiAdRequestController,
-                builder: (_, multiAdRequestSnapshot) {
-                  if (multiAdRequestSnapshot.hasData) {
-                    debugPrint(
-                      'MultiAdRequestController initialized, '
-                      'success=${multiAdRequestSnapshot.data}',
-                    );
-
-                    return SingleChildScrollView(
-                      controller: _scrollController,
-                      child: Column(
-                        children: [
-                          TextButton(
-                            onPressed: () {
-                              _multiAdRequestController.loadAds();
-                            },
-                            child: const Text('load ads'),
-                          ),
-                          const Text(
-                              'typesetting industry. Lorem has been the boo '
-                              'standard dummy text ever sin 1500s, when an aha '
-                              'Lorem Ipsum is simply dummy f the printing and '
-                              'printer took a galley of boo it to m'),
-                          const Padding(
-                            padding: EdgeInsets.symmetric(vertical: 8),
-                            child: Align(
-                              alignment: Alignment.topLeft,
-                              child: Text(
-                                'fit to container:',
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                          AdBanner(
-                            controller: _controller,
-                            //placementID: '17058950',
-                            inventoryCode:
-                                'bunte_webdesktop_home_homepage_hor_1',
-                            adSizes: const [
-                              AdSize(728, 90),
-                            ], //[AdSize(300, 250)],
-                            customKeywords: useDemoAds,
-                            resizeAdToFitContainer: true,
-                            multiAdRequestController: _multiAdRequestController,
-                          ),
-                          const Text(
-                              'Lorem Ipsum is simply text of the printing and '
-                              'typesetting industry. Ipsum has been the boo '
-                              'standard dummy text as the 1500s, when an aha '
-                              'printer took a galley e and scrambled it to v'),
-                          const Padding(
-                            padding: EdgeInsets.symmetric(vertical: 8),
-                            child: Align(
-                              alignment: Alignment.topLeft,
-                              child: Text(
-                                'fit to container:',
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                          AdBanner(
-                            controller: _controller,
-                            //placementID: '17058950',
-                            inventoryCode:
-                                'bunte_webdesktop_home_homepage_hor_1',
-                            adSizes: const [
-                              AdSize(728, 90),
-                            ], //[AdSize(300, 250)],
-                            customKeywords: useDemoAds,
-                            resizeAdToFitContainer: true,
-                            multiAdRequestController: _multiAdRequestController,
-                          ),
-                          const Text(
-                              'Lorem Ipsum is simp du text of the printing and '
-                              'typesetting industry. Lo Ipsum has been the boo '
-                              'standard dummy text as the 1500s, when an aha '
-                              'printer took a galley as and scrambled it to g'),
-                          const Padding(
-                            padding: EdgeInsets.symmetric(vertical: 8),
-                            child: Align(
-                              alignment: Alignment.topLeft,
-                              child: Text(
-                                'fit to container:',
-                                style: TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                            ),
-                          ),
-                          AdBanner(
-                            controller: _controller,
-                            //placementID: '17058950',
-                            inventoryCode:
-                                'bunte_webdesktop_home_homepage_hor_1',
-                            adSizes: const [
-                              AdSize(728, 90),
-                            ], //[AdSize(300, 250)],
-                            customKeywords: useDemoAds,
-                            resizeAdToFitContainer: true,
-                            multiAdRequestController: _multiAdRequestController,
-                          ),
-                        ],
-                      ),
-                    );
-                  } else if (multiAdRequestSnapshot.hasError) {
-                    debugPrint(
-                      'Error initializing MultiAdRequestController: '
-                      '${multiAdRequestSnapshot.error}',
-                    );
-                    return const Text('Error initializing multi ad request');
-                  } else {
-                    debugPrint('Initializing MultiAdRequestController...');
-                    return const Text('Initializing multi ad request...');
-                  }
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          child: Column(
+            children: [
+              TextButton(
+                onPressed: () {
+                  _multiAdRequestController.loadAds();
                 },
-              );
-            } else if (xandrSnapshot.hasError) {
-              return const Text('Error initializing Xandr SDK');
-            } else {
-              return const Text('Initializing Xandr SDK...');
-            }
-          },
+                child: const Text('load ads'),
+              ),
+              const Text('typesetting industry. Lorem has been the boo '
+                  'standard dummy text ever sin 1500s, when an aha '
+                  'Lorem Ipsum is simply dummy f the printing and '
+                  'printer took a galley of boo it to m'),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    'fit to container:',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              AdBanner(
+                controller: _controller,
+                //placementID: '17058950',
+                inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+                adSizes: const [
+                  AdSize(728, 90),
+                ], //[AdSize(300, 250)],
+                customKeywords: useDemoAds,
+                resizeAdToFitContainer: true,
+                multiAdRequestController: _multiAdRequestController,
+              ),
+              const Text('Lorem Ipsum is simply text of the printing and '
+                  'typesetting industry. Ipsum has been the boo '
+                  'standard dummy text as the 1500s, when an aha '
+                  'printer took a galley e and scrambled it to v'),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    'fit to container:',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              AdBanner(
+                controller: _controller,
+                //placementID: '17058950',
+                inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+                adSizes: const [
+                  AdSize(728, 90),
+                ], //[AdSize(300, 250)],
+                customKeywords: useDemoAds,
+                resizeAdToFitContainer: true,
+                multiAdRequestController: _multiAdRequestController,
+              ),
+              const Text('Lorem Ipsum is simp du text of the printing and '
+                  'typesetting industry. Lo Ipsum has been the boo '
+                  'standard dummy text as the 1500s, when an aha '
+                  'printer took a galley as and scrambled it to g'),
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    'fit to container:',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ),
+              AdBanner(
+                controller: _controller,
+                //placementID: '17058950',
+                inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+                adSizes: const [
+                  AdSize(728, 90),
+                ], //[AdSize(300, 250)],
+                customKeywords: useDemoAds,
+                resizeAdToFitContainer: true,
+                multiAdRequestController: _multiAdRequestController,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/packages/xandr/lib/ad_banner.dart
+++ b/packages/xandr/lib/ad_banner.dart
@@ -178,36 +178,57 @@ class _AdBannerState extends State<AdBanner> {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: _width, //adSizes.first.width.toDouble(),
-      height: _height, //adSizes.first.height.toDouble(),
-      child: _HostAdBannerView(
-        placementID: widget.placementID,
-        inventoryCode: widget.inventoryCode,
-        adSizes: widget.adSizes,
-        customKeywords: widget.customKeywords ?? {},
-        allowNativeDemand: widget.allowNativeDemand,
-        autoRefreshInterval: widget.autoRefreshInterval,
-        resizeWhenLoaded: widget.resizeWhenLoaded,
-        controller: widget.controller,
-        layoutHeight: _height.toInt(),
-        layoutWidth: _width.toInt(),
-        clickThroughAction: widget.clickThroughAction,
-        resizeAdToFitContainer: widget.resizeAdToFitContainer,
-        loadsInBackground: widget.loadsInBackground,
-        shouldServePSAs: widget.shouldServePSAs,
-        loadMode: widget.loadMode,
-        onDoneLoading: onDoneLoading,
-        widgetId: _widgetId,
-        enableLazyLoad: widget.enableLazyLoad,
-        multiAdRequestId: widget.multiAdRequestController?.requestId,
-        delegate: BannerAdEventDelegate(
-          onBannerAdLoaded: (event) {
-            debugPrint('>>>> onBannerAdLoaded: $event');
-            changeSize(event.width.toDouble(), event.height.toDouble());
-          },
-        ),
-      ),
+    return FutureBuilder(
+      future: widget.controller.isInitialized.future,
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          if (snapshot.data!) {
+            return SizedBox(
+              width: _width, //adSizes.first.width.toDouble(),
+              height: _height, //adSizes.first.height.toDouble(),
+              child: _HostAdBannerView(
+                placementID: widget.placementID,
+                inventoryCode: widget.inventoryCode,
+                adSizes: widget.adSizes,
+                customKeywords: widget.customKeywords ?? {},
+                allowNativeDemand: widget.allowNativeDemand,
+                autoRefreshInterval: widget.autoRefreshInterval,
+                resizeWhenLoaded: widget.resizeWhenLoaded,
+                controller: widget.controller,
+                layoutHeight: _height.toInt(),
+                layoutWidth: _width.toInt(),
+                clickThroughAction: widget.clickThroughAction,
+                resizeAdToFitContainer: widget.resizeAdToFitContainer,
+                loadsInBackground: widget.loadsInBackground,
+                shouldServePSAs: widget.shouldServePSAs,
+                loadMode: widget.loadMode,
+                onDoneLoading: onDoneLoading,
+                widgetId: _widgetId,
+                enableLazyLoad: widget.enableLazyLoad,
+                multiAdRequestId: widget.multiAdRequestController?.requestId,
+                delegate: BannerAdEventDelegate(
+                  onBannerAdLoaded: (event) {
+                    debugPrint('>>>> onBannerAdLoaded: $event');
+                    changeSize(event.width.toDouble(), event.height.toDouble());
+                  },
+                ),
+              ),
+            );
+          } else {
+            return const Text('Error initializing Xandr, error: false');
+          }
+        } else if (snapshot.hasError) {
+          return const Text('unknown Error initializing Xandr');
+        } else {
+          return SizedBox(
+            width: _width, //adSizes.first.width.toDouble(),
+            height: _height, //adSizes.first.height.toDouble(),
+            child: const Center(
+              child: Text('loading xandr...'),
+            ),
+          );
+        }
+      },
     );
   }
 }

--- a/packages/xandr/lib/ad_banner.dart
+++ b/packages/xandr/lib/ad_banner.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:developer';
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -228,7 +227,6 @@ class _AdBannerState extends State<AdBanner> {
             return const Text('Error initializing Xandr, error: false');
           }
         } else if (snapshot.hasError) {
-          debugPrint(">> ERROR ${snapshot.error}");
           return const Text('unknown Error initializing Xandr');
         } else {
           return SizedBox(

--- a/packages/xandr/lib/ad_banner.dart
+++ b/packages/xandr/lib/ad_banner.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -176,10 +177,19 @@ class _AdBannerState extends State<AdBanner> {
     });
   }
 
+  Future<bool> waitIsInitialized() async {
+    final xandrIsInitialized = await widget.controller.isInitialized.future;
+    if (!xandrIsInitialized) return false;
+    if (widget.multiAdRequestController == null) return xandrIsInitialized;
+    final multiAdrequestInitialized =
+        await widget.multiAdRequestController!.isInitialized.future;
+    return multiAdrequestInitialized;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: widget.controller.isInitialized.future,
+    return FutureBuilder<bool>(
+      future: waitIsInitialized(),
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           if (snapshot.data!) {
@@ -218,6 +228,7 @@ class _AdBannerState extends State<AdBanner> {
             return const Text('Error initializing Xandr, error: false');
           }
         } else if (snapshot.hasError) {
+          debugPrint(">> ERROR ${snapshot.error}");
           return const Text('unknown Error initializing Xandr');
         } else {
           return SizedBox(

--- a/packages/xandr/lib/xandr.dart
+++ b/packages/xandr/lib/xandr.dart
@@ -25,6 +25,9 @@ class XandrController {
     _platform.registerEventStream(controller: _eventStreamController);
   }
 
+  /// A completer that indicates whether the initialization is complete or not.
+  final Completer<bool> isInitialized = Completer();
+
   final StreamController<BannerAdEvent> _eventStreamController =
       StreamController.broadcast();
 
@@ -33,7 +36,13 @@ class XandrController {
   /// [memberId] is the Xandr member ID.
   Future<bool> init(int memberId) async {
     debugPrint('init xandr with memberId=$memberId');
-    return _platform.init(memberId);
+    if (isInitialized.isCompleted) {
+      return isInitialized.future;
+    }
+    await Future.delayed(const Duration(seconds: 10));
+    final result = await _platform.init(memberId);
+    isInitialized.complete(result);
+    return result;
   }
 
   /// loads an ad.

--- a/packages/xandr/lib/xandr.dart
+++ b/packages/xandr/lib/xandr.dart
@@ -13,14 +13,6 @@ class XandrController {
   /// This class is responsible for controlling the Xandr functionality.
   /// It initializes the necessary components and provides methods for
   /// interacting with Xandr.
-  ///
-  /// Example usage:
-  ///
-  /// ```dart
-  /// XandrController controller = XandrController();
-  /// controller.initialize();
-  /// controller.start();
-  /// ```
   XandrController() {
     _platform.registerEventStream(controller: _eventStreamController);
   }
@@ -39,7 +31,6 @@ class XandrController {
     if (isInitialized.isCompleted) {
       return isInitialized.future;
     }
-    await Future.delayed(const Duration(seconds: 10));
     final result = await _platform.init(memberId);
     isInitialized.complete(result);
     return result;
@@ -95,19 +86,47 @@ class XandrController {
 
 /// The controller for handling multi ad requests.
 class MultiAdRequestController {
+  /// Controller for handling multi ad requests.
+  ///
+  /// This controller is responsible for managing multiple ad requests
+  /// and coordinating with the XandrController.
+  MultiAdRequestController({required XandrController controller})
+      : _controller = controller;
+
   String? _multiAdRequestID;
+  final XandrController _controller;
 
   /// Returns the request ID associated with the multi-ad request.
   /// If no request ID is available, it returns `null`.
   String? get requestId => _multiAdRequestID;
+
+  /// A completer that indicates whether the initialization is complete or not.
+  final Completer<bool> isInitialized = Completer();
+
+  /// Initializes the application when Xandr is ready.
+  ///
+  /// Returns a [Future] that completes with a boolean value indicating whether
+  /// the initialization was successful.
+  Future<bool> initWhenXandrIsReady() async {
+    if (_controller.isInitialized.isCompleted) {
+      return _controller.isInitialized.future;
+    }
+    await _controller.isInitialized.future;
+    return init();
+  }
 
   /// Initializes the Xandr library.
   ///
   /// Returns a [Future] that completes with a [bool] value indicating whether
   /// the initialization was successful.
   Future<bool> init() async {
+    if (isInitialized.isCompleted) {
+      return isInitialized.future;
+    }
     _multiAdRequestID = await _platform.initMultiAdRequest();
-    return _multiAdRequestID != null;
+    final result = _multiAdRequestID != null;
+    isInitialized.complete(result);
+    return result;
   }
 
   /// Disposes the resources used by this object.


### PR DESCRIPTION
This removes the need to run the xandr and multi ad request builders in favour of a new mechanic to just wait for the init of this controller to complete

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
