### PR TITLE
Added constraints to scroll listener

### DIFF
--- a/packages/xandr/lib/ad_banner.dart
+++ b/packages/xandr/lib/ad_banner.dart
@@ -144,6 +144,7 @@ class _AdBannerState extends State<AdBanner> {
 
   /// function used only with the [WhenInViewport] loadMode
   void _checkViewport(int pixelOffset) {
+    if (!mounted || !context.mounted) return;
     final object = context.findRenderObject();
 
     if (object == null || !object.attached) {

--- a/packages/xandr/lib/load_mode.dart
+++ b/packages/xandr/lib/load_mode.dart
@@ -48,7 +48,11 @@ class LoadWhenCreated extends LoadMode {
 class WhenInViewport extends LoadMode {
   /// load ad when it's in the viewport
   WhenInViewport({required this.checkIfInViewport, int? pixelOffset})
-      : pixelOffset = pixelOffset ?? 0,
+      : assert(
+          checkIfInViewport.isBroadcast,
+          'The stream must be of broadcast type.',
+        ),
+        pixelOffset = pixelOffset ?? 0,
         super._();
 
   /// stream which should get new events when scrolling changes


### PR DESCRIPTION
…k to scroll checker in AdBanner.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Added a check to __checkViewport_ method (AdBanner class) to prevent the execution when the widget or its context are not mounted;
- Added an assertion to WhenInViewport class to force the _checkIfInViewport_ stream to be passed as a broadcast: not doing that can lead to **Bad State** errors due to "stream already listened" phenomena.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
