### PR TITLE
chore: ios platform version was set to 12.0

### DIFF
--- a/packages/xandr_ios/ios/xandr_ios.podspec
+++ b/packages/xandr_ios/ios/xandr_ios.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.dependency 'AppNexusSDK', '9.0.0'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '12.0'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
## Description

AppNexusSDK 9.0.0 require iOS 12.0 or higher

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
