### PR TITLE
feat: add optional nativeAdRendererId to add requests (#218)

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -1,4 +1,3 @@
-
 name: xandr
 
 packages:
@@ -20,29 +19,28 @@ command:
     # branch: master
     # Additionally build a changelog at the root of the workspace.
     workspaceChangelog: true
-    
+
 scripts:
   analyze: fvm flutter analyze .
 
-  pana: 
+  pana:
     run: |
       fvm dart run pana . --exit-code-threshold 100 2>&1
     exec:
       concurrency: 1
     packageFilters:
       ignore:
-        - '*example*'
+        - "*example*"
     description: Run pana for each package.
 
   format:
     run: |
       melos format && \
       swiftformat . 2>&1 && \
-      ktlint --format '**/*.kt' '**/*.kts' '!**/*.g.kt' 
+      ktlint --format '**/*.kt' '**/*.kts' '!**/*.g.kt'
     description: |
-       - Requires `swiftformat` (can be installed via Brew on macOS).
-       - Requires `ktlint` (can be installed via Brew on macOS).
-
+      - Requires `swiftformat` (can be installed via Brew on macOS).
+      - Requires `ktlint` (can be installed via Brew on macOS).
 
   test:all:
     run: |
@@ -60,7 +58,7 @@ scripts:
       dirExists:
         - test
       ignore:
-        - '*example*'
+        - "*example*"
 
   generate:pigeon:
     run: |
@@ -95,7 +93,7 @@ scripts:
     exec:
       concurrency: 1
     packageFilters:
-        scope: 'xandr_example'
+      scope: "xandr_example"
 
   run:example:interstitial:
     run: fvm flutter run -t lib/main_interstitial.dart
@@ -103,7 +101,7 @@ scripts:
     exec:
       concurrency: 1
     packageFilters:
-        scope: 'xandr_example'
+      scope: "xandr_example"
 
   run:example:multiadrequest:
     run: fvm flutter run -t lib/main_multi_ad_request.dart
@@ -111,7 +109,7 @@ scripts:
     exec:
       concurrency: 1
     packageFilters:
-        scope: 'xandr_example'
+      scope: "xandr_example"
 
   run:example:fadeOnDone:
     run: fvm flutter run -t lib/main_fade_on_done.dart
@@ -119,4 +117,12 @@ scripts:
     exec:
       concurrency: 1
     packageFilters:
-        scope: 'xandr_example'
+      scope: "xandr_example"
+
+  run:example:native:
+    run: fvm flutter run -t lib/main_native.dart
+    description: Run the example app inclusing just a native ad banner.
+    exec:
+      concurrency: 1
+    packageFilters:
+      scope: "xandr_example"

--- a/packages/xandr/example/android/settings.gradle
+++ b/packages/xandr/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.8.0" apply false
+    id "com.android.application" version '8.8.1' apply false
     id "org.jetbrains.kotlin.android" version "2.1.10" apply false
 }
 

--- a/packages/xandr/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/xandr/example/ios/Runner.xcodeproj/project.pbxproj
@@ -141,7 +141,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				A690E23C821F3F1748555F86 /* [CP] Copy Pods Resources */,
-				5217989D30CC84BAF094CE0C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,23 +221,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		5217989D30CC84BAF094CE0C /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		6BD081C33623EE5F6D3EFFF8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/packages/xandr/example/lib/main_native.dart
+++ b/packages/xandr/example/lib/main_native.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:xandr/ad_banner.dart';
 import 'package:xandr/ad_size.dart';
-import 'package:xandr/load_mode.dart';
 import 'package:xandr/xandr.dart';
 
 void main() {

--- a/packages/xandr/example/lib/main_native.dart
+++ b/packages/xandr/example/lib/main_native.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:xandr/ad_banner.dart';
+import 'package:xandr/ad_size.dart';
+import 'package:xandr/load_mode.dart';
+import 'package:xandr/xandr.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
+      ),
+      home: const XandrExample(),
+    );
+  }
+}
+
+class XandrExample extends StatefulWidget {
+  const XandrExample({super.key});
+
+  @override
+  State<XandrExample> createState() => _XandrExampleState();
+}
+
+class _XandrExampleState extends State<XandrExample> {
+  late final XandrController _controller;
+  final ScrollController _scrollController = ScrollController();
+  final StreamController<ScrollPosition> _checkIfAdIsInViewport =
+      StreamController.broadcast();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    _checkIfAdIsInViewport.close();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = XandrController()..init(9517, testMode: true);
+    _scrollController.addListener(() {
+      _checkIfAdIsInViewport.add(_scrollController.position);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+          title: const Text('xandr sample - banner'),
+        ),
+        body: Center(
+          child: SingleChildScrollView(
+            controller: _scrollController,
+            child: Column(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 8),
+                  child: Align(
+                    alignment: Alignment.topLeft,
+                    child: Text(
+                      'native ad below:',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                AdBanner(
+                  controller: _controller,
+                  inventoryCode: 'bunte_webdesktop_home_homepage_hor_1',
+                  adSizes: const [AdSize(1, 1)],
+                  customKeywords: const {
+                    'kw': ['test-kw', 'demoads_native'],
+                  },
+                  onBannerFinishLoading: ({
+                    required success,
+                    height,
+                    width,
+                    nativeAd,
+                  }) =>
+                      debugPrint(
+                    'on native banner finish loading: success: $success',
+                  ),
+                  autoRefreshInterval: Duration.zero,
+                  clickThroughAction: ClickThroughAction.returnUrl,
+                  onAdClicked: (url) => debugPrint('click url: $url'),
+                  allowNativeDemand: true,
+                  nativeAdBuilder: (nativeAd) => InkWell(
+                    onTap: () => debugPrint(
+                      'native ad click: ${nativeAd.clickUrl}',
+                    ),
+                    child: ColoredBox(
+                      color: Colors.amber,
+                      child: Column(
+                        children: [
+                          Text(nativeAd.title),
+                          Text(nativeAd.description),
+                          Image.network(nativeAd.imageUrl),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/xandr/example/lib/main_native.dart
+++ b/packages/xandr/example/lib/main_native.dart
@@ -102,6 +102,7 @@ class _XandrExampleState extends State<XandrExample> {
                   clickThroughAction: ClickThroughAction.returnUrl,
                   onAdClicked: (url) => debugPrint('click url: $url'),
                   allowNativeDemand: true,
+                  nativeAdRendererId: 1,
                   nativeAdBuilder: (nativeAd) => InkWell(
                     onTap: () => debugPrint(
                       'native ad click: ${nativeAd.clickUrl}',

--- a/packages/xandr/lib/ad_banner.dart
+++ b/packages/xandr/lib/ad_banner.dart
@@ -25,6 +25,7 @@ class AdBanner extends StatefulWidget {
     this.autoRefreshInterval = const Duration(seconds: 30),
     this.resizeWhenLoaded = false,
     this.allowNativeDemand = false,
+    this.nativeAdRendererId,
     this.nativeAdBuilder,
     this.clickThroughAction,
     this.resizeAdToFitContainer = false,
@@ -46,6 +47,11 @@ class AdBanner extends StatefulWidget {
           (allowNativeDemand == false && nativeAdBuilder == null) ||
               (allowNativeDemand == true && nativeAdBuilder != null),
           'nativeAdBuilder must be set if allowNativeDemand is true',
+        ),
+        assert(
+          (nativeAdRendererId != null && allowNativeDemand == true) ||
+              nativeAdRendererId == null,
+          'allowNativeDemand must be true if nativeAdRendererId is set',
         ),
         //Note: opensdk:auto_refresh_interval or
         // adview.setAutoRefreshInterval(long interval): The interval, in
@@ -97,6 +103,12 @@ class AdBanner extends StatefulWidget {
 
   /// Whether to allow native ads to be served
   final bool allowNativeDemand;
+
+  /// The ID of the native ad renderer.
+  ///
+  /// This is an optional field that can be used to specify a custom renderer
+  /// for native ads. If not provided, the default renderer will be used.
+  final int? nativeAdRendererId;
 
   /// The width of the ad banner.
   final double width;
@@ -278,6 +290,7 @@ class _AdBannerState extends State<AdBanner> {
               multiAdRequestId: widget.multiAdRequestController?.requestId,
               onAdClicked: widget.onAdClicked,
               allowNativeDemand: widget.allowNativeDemand,
+              nativeAdRendererId: widget.nativeAdRendererId,
               nativeAdWidget: nativeAdWidget(),
             );
           } else {
@@ -369,6 +382,7 @@ class _HostAdBannerView extends StatelessWidget {
     required List<AdSize> adSizes,
     required CustomKeywords customKeywords,
     required bool allowNativeDemand,
+    required int? nativeAdRendererId,
     required Duration autoRefreshInterval,
     required bool resizeWhenLoaded,
     required this.controller,
@@ -413,6 +427,9 @@ class _HostAdBannerView extends StatelessWidget {
     }
     if (multiAdRequestId != null) {
       creationParams['multiAdRequestId'] = multiAdRequestId;
+    }
+    if (nativeAdRendererId != null) {
+      creationParams['nativeAdRendererId'] = nativeAdRendererId;
     }
   }
 

--- a/packages/xandr_android/android/src/main/kotlin/de/thekorn/xandr/models/BannerViewOptions.kt
+++ b/packages/xandr_android/android/src/main/kotlin/de/thekorn/xandr/models/BannerViewOptions.kt
@@ -7,6 +7,7 @@ data class BannerViewOptions(
     val adSizes: ArrayList<AdSize>? = null,
     val customKeywords: HashMap<String, List<String>>? = null,
     val allowNativeDemand: Boolean? = null,
+    val nativeAdRendererId: Int? = null,
     val layoutWidth: Int? = null,
     val layoutHeight: Int? = null,
     val shouldServePSAs: Boolean? = null,
@@ -38,6 +39,11 @@ fun Map<*, *>.toBannerAdViewOptions(): BannerViewOptions {
         "Xandr.BannerViewOptions",
         "using '$adSizes' -> '$sizes'"
     )
+    Log.d(
+        "Xandr.BannerViewOptions",
+        "using 'nativeAdRendererId' -> '${this["nativeAdRendererId"]}'"
+    )
+
 
     val customKeywords = HashMap<String, List<String>>()
     val keywords = this["customKeywords"] as HashMap<*, *>?
@@ -60,6 +66,7 @@ fun Map<*, *>.toBannerAdViewOptions(): BannerViewOptions {
         autoRefreshInterval = this["autoRefreshInterval"] as Int?,
         resizeWhenLoaded = this["resizeWhenLoaded"] as Boolean?,
         allowNativeDemand = this["allowNativeDemand"] as Boolean?,
+        nativeAdRendererId = this["nativeAdRendererId"] as Int?,
         loadWhenCreated = this["loadWhenCreated"] as Boolean?,
         enableLazyLoad = this["enableLazyLoad"] as Boolean?,
         multiAdRequestId = this["multiAdRequestId"] as String?

--- a/packages/xandr_android/android/src/main/kotlin/de/thekorn/xandr/models/ads/BannerAd.kt
+++ b/packages/xandr_android/android/src/main/kotlin/de/thekorn/xandr/models/ads/BannerAd.kt
@@ -47,6 +47,10 @@ class BannerAd(
                 this.allowNativeDemand = allowNativeDemand
             }
 
+            it.nativeAdRendererId?.let { nativeAdRendererId ->
+                this.rendererId = nativeAdRendererId
+            }
+
             it.shouldServePSAs?.let { shouldServePSAs ->
                 this.shouldServePSAs = shouldServePSAs
             }

--- a/packages/xandr_ios/ios/Classes/models/ads/BannerAd.swift
+++ b/packages/xandr_ios/ios/Classes/models/ads/BannerAd.swift
@@ -43,6 +43,7 @@ class XandrBanner: NSObject, FlutterPlatformView, ANBannerAdViewDelegate {
     let autoRefreshInterval = arguments["autoRefreshInterval"] as? Double ?? 30
     // let resizeWhenLoaded = arguments["resizeWhenLoaded"] as? Bool ?? false
     let allowNativeDemand = arguments["allowNativeDemand"] as? Bool ?? false
+    let nativeAdRendererId = arguments["nativeAdRendererId"] as? Int
     // let loadWhenCreated = arguments["loadWhenCreated"] as? Bool ?? false
     let enableLazyLoad = arguments["enableLazyLoad"] as? Bool ?? false
     // let multiAdRequestId = arguments["multiAdRequestId"] as? String
@@ -78,6 +79,10 @@ class XandrBanner: NSObject, FlutterPlatformView, ANBannerAdViewDelegate {
       banner?.autoRefreshInterval = autoRefreshInterval
       banner?.shouldAllowNativeDemand = allowNativeDemand
       banner?.enableLazyLoad = enableLazyLoad
+      if nativeAdRendererId != nil {
+        banner?.nativeAdRendererId = nativeAdRendererId!
+          logger.debug(message: "using nativeAdRendererId=\(String(describing: nativeAdRendererId))")
+      }
 
       if clickThroughAction != nil {
         switch clickThroughAction {


### PR DESCRIPTION
Implement new optional `AdBanner.nativeAdRendererId`

```
  /// The ID of the native ad renderer.
  ///
  /// This is an optional field that can be used to specify a custom renderer
  /// for native ads. If not provided, the default renderer will be used.
  final int? nativeAdRendererId;
```

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
